### PR TITLE
Fix import errors by switching to absolute imports

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -1,8 +1,8 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
-from ..database import SessionLocal
-from ..models import Device, EnergyData
-from ..crud import get_device_by_mac
+from database import SessionLocal
+from models import Device, EnergyData
+from crud import get_device_by_mac
 
 router = APIRouter()
 

--- a/crud.py
+++ b/crud.py
@@ -1,5 +1,5 @@
 from sqlalchemy.orm import Session
-from .models import Device, EnergyData
+from models import Device, EnergyData
 
 def get_device_by_mac(db: Session, mac: str):
     return db.query(Device).filter(Device.mac == mac).first()

--- a/main.py
+++ b/main.py
@@ -2,9 +2,9 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 import threading
-from .mqtt_worker import mqtt_worker
-from .database import Base, engine
-from .api.routes import router as api_router
+from mqtt_worker import mqtt_worker
+from database import Base, engine
+from api.routes import router as api_router
 
 Base.metadata.create_all(bind=engine)
 

--- a/models.py
+++ b/models.py
@@ -1,7 +1,7 @@
 from sqlalchemy import Column, Integer, Float, String, DateTime, ForeignKey
 from sqlalchemy.orm import relationship
 from datetime import datetime
-from .database import Base
+from database import Base
 
 class Device(Base):
     __tablename__ = "devices"

--- a/mqtt_worker.py
+++ b/mqtt_worker.py
@@ -3,9 +3,9 @@ import json
 import os
 import time
 from queue import Queue
-from .database import SessionLocal
-from .models import Device
-from .crud import get_device_by_mac, save_reading
+from database import SessionLocal
+from models import Device
+from crud import get_device_by_mac, save_reading
 
 MQTT_BROKER = "35.188.202.130"
 MQTT_PORT = 1883


### PR DESCRIPTION
## Summary
- use absolute imports across modules so `python main.py` works

## Testing
- `python -m py_compile *.py api/*.py`
- `python main.py` *(fails: No module named 'paho')*

------
https://chatgpt.com/codex/tasks/task_e_687aad29ba8c83298f8cc4c88b89a5f6