### PR TITLE
Fix PendingRollbackError by rolling back sessions

### DIFF
--- a/crud.py
+++ b/crud.py
@@ -7,12 +7,20 @@ def get_device_by_mac(db: Session, mac: str):
 def create_device(db: Session, device_data):
     db_device = Device(**device_data)
     db.add(db_device)
-    db.commit()
-    db.refresh(db_device)
+    try:
+        db.commit()
+        db.refresh(db_device)
+    except Exception:
+        db.rollback()
+        raise
     return db_device
 
 def save_reading(db: Session, voltage, current, device_id):
     reading = EnergyData(voltage=voltage, current=current, device_id=device_id)
     db.add(reading)
-    db.commit()
+    try:
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
     return reading

--- a/mqtt_worker.py
+++ b/mqtt_worker.py
@@ -77,4 +77,5 @@ def mqtt_worker():
                     logger.info("Saved reading for %s: %s", mac, result)
         except Exception:
             logger.exception("Error in MQTT worker loop")
+            db.rollback()
             time.sleep(1)


### PR DESCRIPTION
## Summary
- rollback the DB session on failures to keep connections valid
- handle commit failures in CRUD operations

## Testing
- `python -m py_compile api/routes.py crud.py database.py main.py models.py mqtt_worker.py`

------
https://chatgpt.com/codex/tasks/task_e_687aefa3ee0c832984ca34558bf36132