### PR TITLE
Fix logging and use UTC timestamps

### DIFF
--- a/models.py
+++ b/models.py
@@ -1,6 +1,6 @@
 from sqlalchemy import Column, Integer, Float, String, DateTime, ForeignKey
 from sqlalchemy.orm import relationship
-from datetime import datetime
+from datetime import datetime, timezone
 from database import Base
 
 class Device(Base):
@@ -15,7 +15,10 @@ class Device(Base):
 class EnergyData(Base):
     __tablename__ = "energy_data"
     id = Column(Integer, primary_key=True, index=True)
-    timestamp = Column(DateTime, default=datetime.utcnow)
+    timestamp = Column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+    )
     # Voltajes y Corrientes (RMS)
     voltage_phase_a = Column(Float, nullable=True)
     voltage_phase_b = Column(Float, nullable=True)

--- a/mqtt_worker.py
+++ b/mqtt_worker.py
@@ -3,7 +3,7 @@ import json
 import os
 import time
 import logging
-from queue import Queue
+from queue import Queue, Empty
 from database import SessionLocal
 from models import Device
 from crud import get_device_by_mac, save_reading
@@ -75,6 +75,8 @@ def mqtt_worker():
                 if device:
                     save_reading(db, result, device.id)
                     logger.info("Saved reading for %s: %s", mac, result)
+        except Empty:
+            logger.debug("Response queue timed out waiting for messages")
         except Exception:
             logger.exception("Error in MQTT worker loop")
             db.rollback()


### PR DESCRIPTION
## Summary
- handle empty response queue in MQTT worker as debug
- store energy data timestamps in UTC with timezone awareness

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687afbd586f48329916f5d643ecf72e2